### PR TITLE
Fix deadcode (duplicate) method canAccess()

### DIFF
--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -316,9 +316,4 @@ abstract class Page extends BasePage
 
         return $name;
     }
-
-    public static function canAccess(): bool
-    {
-        return true;
-    }
 }


### PR DESCRIPTION
## Description

The canAccess() method duplicates the implementation of the used [CanAuthorizeAccess](https://github.com/filamentphp/filament/blob/479a1a2b0a8c7e5df6d8b75feed357a03b06f08d/packages/panels/src/Pages/Concerns/CanAuthorizeAccess.php#L12) trait.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
